### PR TITLE
Add middle-click-to-close support for tab headers

### DIFF
--- a/src/XenoAtom.Terminal.UI.Tests/TabControlFeatureTests.cs
+++ b/src/XenoAtom.Terminal.UI.Tests/TabControlFeatureTests.cs
@@ -56,6 +56,44 @@ public sealed class TabControlFeatureTests
     }
 
     [TestMethod]
+    public void TabControl_MiddleClick_Removes_Tab()
+    {
+        var closable = new TabPage("One", new TextBlock("A"))
+        {
+            ShowCloseButton = true,
+        };
+
+        var requestClosingCount = 0;
+        var closedCount = 0;
+        closable.RequestClosing += (_, e) =>
+        {
+            requestClosingCount++;
+            Assert.AreEqual(TabCloseReason.MiddleClick, e.Reason);
+            Assert.AreEqual(0, e.Index);
+        };
+        closable.Closed += (_, e) =>
+        {
+            closedCount++;
+            Assert.AreEqual(TabCloseReason.MiddleClick, e.Reason);
+            Assert.AreEqual(0, e.Index);
+        };
+
+        var tabs = new TabControl(
+            closable,
+            new TabPage("Two", new TextBlock("B")));
+
+        using var driver = new TerminalAppTestDriver(tabs, TerminalHostKind.Fullscreen, new TerminalSize(30, 8));
+        driver.Tick();
+
+        var tabPoint = GetHeaderPoint(tabs, 0, closeButton: false);
+        driver.Backend.PushEvent(new TerminalMouseEvent { Kind = TerminalMouseKind.Down, Button = TerminalMouseButton.Middle, X = tabPoint.X, Y = tabPoint.Y });
+        driver.TickUntil(() => tabs.Tabs.Count == 1);
+
+        Assert.AreEqual(1, requestClosingCount);
+        Assert.AreEqual(1, closedCount);
+    }
+
+    [TestMethod]
     public void TabControl_Cancelled_Close_Request_Leaves_Tab_Open()
     {
         var closable = new TabPage("One", new TextBlock("A"))

--- a/src/XenoAtom.Terminal.UI/Controls/TabControl.cs
+++ b/src/XenoAtom.Terminal.UI/Controls/TabControl.cs
@@ -592,6 +592,22 @@ public sealed partial class TabControl : Visual
     /// <inheritdoc/>
     protected override void OnPointerPressed(PointerEventArgs e)
     {
+        if (e.Button == TerminalMouseButton.Middle)
+        {
+            var middleLocalY = e.UiY - Bounds.Y;
+            if (middleLocalY >= 0 && middleLocalY < _headerHeight)
+            {
+                var middleTarget = HitTestHeader(e.UiX - Bounds.X);
+                if ((middleTarget.Part == TabHeaderPart.Tab || middleTarget.Part == TabHeaderPart.CloseButton) && IsTargetEnabled(middleTarget))
+                {
+                    TryCloseTab(middleTarget.Index, TabCloseReason.MiddleClick);
+                    e.Handled = true;
+                }
+            }
+
+            return;
+        }
+
         if (e.Button != TerminalMouseButton.Left)
         {
             return;

--- a/src/XenoAtom.Terminal.UI/Controls/TabPage.cs
+++ b/src/XenoAtom.Terminal.UI/Controls/TabPage.cs
@@ -148,6 +148,11 @@ public enum TabCloseReason
     /// The close request originated from the tab header close button.
     /// </summary>
     CloseButton,
+
+    /// <summary>
+    /// The close request originated from a middle-click on the tab header.
+    /// </summary>
+    MiddleClick,
 }
 
 /// <summary>


### PR DESCRIPTION
Add middle-click-to-close support for tab headers

## Summary
When a tab shows a close button, users can now also close it by middle-clicking anywhere on the tab header (not just the close button glyph).
This is a common pattern, used in applications like browsers.

## Changes
- **Added `TabCloseReason.MiddleClick`** to distinguish close requests initiated via middle-click.
- **Updated `TabControl.OnPointerPressed`** so that a middle-click on a tab header (tab body or close button area) immediately triggers the same close flow as clicking the close button.
- **Added regression test** `TabControl_MiddleClick_Removes_Tab` that verifies the tab is removed and the correct `TabCloseReason` is raised.

## Verification
- Full test suite passes (`894` tests).
- Middle-click on a disabled tab is correctly ignored (respects existing `IsTargetEnabled` checks).