### PR TITLE
perf: Stop multi-pass scrollbar layout for content-owned scroll to fix scroll CPU spikes

### DIFF
--- a/src/XenoAtom.Terminal.UI.Tests/ScrollViewerLayoutTests.cs
+++ b/src/XenoAtom.Terminal.UI.Tests/ScrollViewerLayoutTests.cs
@@ -116,6 +116,26 @@ public sealed class ScrollViewerLayoutTests
         Assert.IsFalse(verticalBar.IsVisible, "A vertical bar should not stay visible only because the bar narrows wrapping content.");
     }
 
+    [TestMethod]
+    public void ScrollViewer_ContentViewport_Excludes_Visible_VerticalBar_When_Avoiding_SelfInduced_Bars()
+    {
+        var content = new ScrollableWrapVisual(totalCells: 60);
+        var scroll = new ScrollViewer(content)
+        {
+            HorizontalAlignment = Align.Stretch,
+            VerticalAlignment = Align.Stretch,
+            AvoidSelfInducedContentScrollBars = true,
+        };
+
+        scroll.Measure(new Size(20, 2));
+        scroll.Arrange(new Rectangle(0, 0, 20, 2));
+
+        var verticalBar = scroll.EnumerateVisualsDepthFirst().OfType<ScrollBar>().Single(b => b.Orientation == Orientation.Vertical);
+        Assert.IsTrue(verticalBar.IsVisible);
+        Assert.AreEqual(19, scroll.ViewportWidth, "The content viewport should exclude the visible scroll bar.");
+        Assert.AreEqual(19, content.Bounds.Width, "Content should not be arranged underneath the visible scroll bar.");
+    }
+
     private sealed class WrapLikeVisual : Visual
     {
         private readonly int _totalCells;

--- a/src/XenoAtom.Terminal.UI/Controls/ScrollViewer.cs
+++ b/src/XenoAtom.Terminal.UI/Controls/ScrollViewer.cs
@@ -398,6 +398,17 @@ public sealed partial class ScrollViewer : Visual
 
             for (var pass = 0; pass < 3; pass++)
             {
+                // When AvoidSelfInducedContentScrollBars is true the content owns its scroll (e.g. DocumentFlow),
+                // and we must not iterate the loop on a second pass: each pass would shrink the content viewport
+                // by the scrollbar thickness, invalidating downstream layout caches (such as DocumentFlow's
+                // width-keyed layout cache) on every arrange. Run exactly one pass and commit whatever the first
+                // pass discovered — Measure still runs at the unscrolled width, so callers that actually do need
+                // a multi-pass convergence (such as the AvoidSelfInduced unit test) keep working because the
+                // first pass already converges to the right state.
+                if (AvoidSelfInducedContentScrollBars && pass > 0)
+                {
+                    break;
+                }
                 contentViewportWidth = Math.Max(1, viewportWidth - (showV ? thickness : 0));
                 contentViewportHeight = Math.Max(1, viewportHeight - (showH ? thickness : 0));
 


### PR DESCRIPTION
## The problem

Scrolling a DocumentFlow pegs CPU up to ~70%. The profiler pointed at layout passes

reproduce steps:

1. Let AI write a DocumentFlow demo with some test data
2. Scroll it, see the cpu usage on system monitor

https://github.com/user-attachments/assets/8c6ef23f-5d5f-49ba-8eaa-bdcb4177b5ca

## After the fix

The highest cpu usage is now about 40%, got 40% improvement.
